### PR TITLE
Remove lazy-loading component logic for Engine

### DIFF
--- a/advisor_engine/__main__.py
+++ b/advisor_engine/__main__.py
@@ -28,7 +28,7 @@ def signal_handler(sig, frame):
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
-archive_processor.setup_components()
+archive_processor.setup_engine()
 archive_processor.resume_existing_archives()
 uvicorn.run(app, host=config.ADVISOR_ENGINE_BIND,
                  port=config.ADVISOR_ENGINE_PORT,

--- a/advisor_engine/__main__.py
+++ b/advisor_engine/__main__.py
@@ -28,7 +28,6 @@ def signal_handler(sig, frame):
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
-archive_processor.setup_engine()
 archive_processor.resume_existing_archives()
 uvicorn.run(app, host=config.ADVISOR_ENGINE_BIND,
                  port=config.ADVISOR_ENGINE_PORT,

--- a/advisor_engine/archive_processor.py
+++ b/advisor_engine/archive_processor.py
@@ -3,20 +3,15 @@ import os
 import shutil
 import traceback
 from advisor_engine import config, loggers, foreman, content
-from advisor_engine.insights_core_engine import (
-    install_rules, setup_broker_and_components, get_engine_results
-)
+from advisor_engine.insights_core_engine import Engine
 import concurrent.futures
 
 logger = loggers.engine_logging()
 rule_content = content.get_rule_content()
+AdvisorEngine = Engine()
+
 
 executor = concurrent.futures.ProcessPoolExecutor(max_workers=config.WORKER_COUNT)
-
-
-def setup_engine():
-    install_rules()
-    setup_broker_and_components()
 
 
 def resume_existing_archives():
@@ -56,7 +51,7 @@ def process_background(file, tries=1, error=None):
 
 
 def process(file):
-    engine_results = get_engine_results(file)
+    engine_results = AdvisorEngine.get_engine_results(file)
     store_results(engine_results)
 
 

--- a/advisor_engine/archive_processor.py
+++ b/advisor_engine/archive_processor.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import traceback
 from advisor_engine import config, loggers, foreman, content
-from advisor_engine.insights_core_engine import install_rules, get_engine_results
+from advisor_engine.insights_core_engine import (
+    install_rules, setup_broker_and_components, get_engine_results
+)
 import concurrent.futures
 
 logger = loggers.engine_logging()
@@ -12,8 +14,9 @@ rule_content = content.get_rule_content()
 executor = concurrent.futures.ProcessPoolExecutor(max_workers=config.WORKER_COUNT)
 
 
-def setup_components():
+def setup_engine():
     install_rules()
+    setup_broker_and_components()
 
 
 def resume_existing_archives():

--- a/advisor_engine/insights_core_engine.py
+++ b/advisor_engine/insights_core_engine.py
@@ -11,7 +11,6 @@ class Engine():
     def __init__(self):
         self.install_rules()
         self.setup_broker_and_components()
-        self.loaded = True
 
 
     def install_rules(self):

--- a/advisor_engine/insights_core_engine.py
+++ b/advisor_engine/insights_core_engine.py
@@ -6,49 +6,53 @@ from insights.core.hydration import initialize_broker
 from insights.core.archives import extract
 
 engine_logger = loggers.engine_logging()
-loaded = False
+
+class Engine():
+    def __init__(self):
+        self.loaded = False
+        self.install_rules()
+        self.setup_broker_and_components()
 
 
-def install_rules():
-    engine_logger.info('Checking if custom rules have been installed...')
-    if os.path.isdir(config.RULES_DIR):
-        engine_logger.info('Custom rules directory exists. Installing custom rules.')
-        try:
-            wheel_files = [os.path.join(config.RULES_DIR, f) for f in os.listdir(config.RULES_DIR) if os.path.isfile(os.path.join(config.RULES_DIR, f))]
-            engine_logger.info(f'Found rule wheel files to install: {wheel_files}')
-            subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--disable-pip-version-check', *wheel_files])
-        except Exception as e:
-            engine_logger.warning('Exception installing custom rules:', e)
-
-
-def setup_broker_and_components():
-    global loaded
-    if not loaded:
-        # Load the base insights-core specs
-        engine_logger.info('Loading base insights-core components.')
-        dr.load_components(
-            'insights.specs.default',
-            'insights.specs.insights_archive',
-            continue_on_error=False
-        )
-        # Try to load additional components if they have been installed
-        if len(config.RULES_COMPONENTS):
+    def install_rules(self):
+        engine_logger.info('Checking if custom rules have been installed...')
+        if os.path.isdir(config.RULES_DIR):
+            engine_logger.info('Custom rules directory exists. Installing custom rules.')
             try:
-                engine_logger.info('Loading additional core components if installed.')
-                dr.load_components(*config.RULES_COMPONENTS)
+                wheel_files = [os.path.join(config.RULES_DIR, f) for f in os.listdir(config.RULES_DIR) if os.path.isfile(os.path.join(config.RULES_DIR, f))]
+                engine_logger.info(f'Found rule wheel files to install: {wheel_files}')
+                subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--disable-pip-version-check', *wheel_files])
             except Exception as e:
-                engine_logger.warning('Exception loading additional components:', e)
-        else:
-            engine_logger.warning('No RULES_COMPONENTS defined in config. '
-                                  'Running Engine with no rule plugins.')
-        loaded = True
+                engine_logger.warning('Exception installing custom rules:', e)
 
 
-def get_engine_results(file):
-    with extract(
-            file, timeout=10, extract_dir=config.UPLOAD_EXTRACTION_DIR
-    ) as extraction:
-        ctx, broker = initialize_broker(extraction.tmp_dir, broker=dr.Broker())
-        with InsightsEvaluator(broker) as evaluator:
-            dr.run({}, broker=broker)
-            return evaluator.get_response()
+    def setup_broker_and_components(self):
+        if not self.loaded:
+            # Load the base insights-core specs
+            engine_logger.info('Loading base insights-core components.')
+            dr.load_components(
+                'insights.specs.default',
+                'insights.specs.insights_archive',
+                continue_on_error=False
+            )
+            # Try to load additional components if they have been installed
+            if len(config.RULES_COMPONENTS):
+                try:
+                    engine_logger.info('Loading additional core components if installed.')
+                    dr.load_components(*config.RULES_COMPONENTS)
+                except Exception as e:
+                    engine_logger.warning('Exception loading additional components:', e)
+            else:
+                engine_logger.warning('No RULES_COMPONENTS defined in config. '
+                                      'Running Engine with no rule plugins.')
+            self.loaded = True
+
+
+    def get_engine_results(self, file):
+        with extract(
+                file, timeout=10, extract_dir=config.UPLOAD_EXTRACTION_DIR
+        ) as extraction:
+            ctx, broker = initialize_broker(extraction.tmp_dir, broker=dr.Broker())
+            with InsightsEvaluator(broker) as evaluator:
+                dr.run({}, broker=broker)
+                return evaluator.get_response()

--- a/advisor_engine/insights_core_engine.py
+++ b/advisor_engine/insights_core_engine.py
@@ -18,12 +18,9 @@ class Engine():
         engine_logger.info('Checking if custom rules have been installed...')
         if os.path.isdir(config.RULES_DIR):
             engine_logger.info('Custom rules directory exists. Installing custom rules.')
-            try:
-                wheel_files = [os.path.join(config.RULES_DIR, f) for f in os.listdir(config.RULES_DIR) if os.path.isfile(os.path.join(config.RULES_DIR, f))]
-                engine_logger.info(f'Found rule wheel files to install: {wheel_files}')
-                subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--disable-pip-version-check', *wheel_files])
-            except Exception as e:
-                engine_logger.warning('Exception installing custom rules:', e)
+            wheel_files = [os.path.join(config.RULES_DIR, f) for f in os.listdir(config.RULES_DIR) if os.path.isfile(os.path.join(config.RULES_DIR, f))]
+            engine_logger.info(f'Found rule wheel files to install: {wheel_files}')
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--disable-pip-version-check', *wheel_files])
 
 
     def setup_broker_and_components(self):

--- a/advisor_engine/insights_core_engine.py
+++ b/advisor_engine/insights_core_engine.py
@@ -9,9 +9,9 @@ engine_logger = loggers.engine_logging()
 
 class Engine():
     def __init__(self):
-        self.loaded = False
         self.install_rules()
         self.setup_broker_and_components()
+        self.loaded = True
 
 
     def install_rules(self):
@@ -27,25 +27,20 @@ class Engine():
 
 
     def setup_broker_and_components(self):
-        if not self.loaded:
-            # Load the base insights-core specs
-            engine_logger.info('Loading base insights-core components.')
-            dr.load_components(
-                'insights.specs.default',
-                'insights.specs.insights_archive',
-                continue_on_error=False
-            )
-            # Try to load additional components if they have been installed
-            if len(config.RULES_COMPONENTS):
-                try:
-                    engine_logger.info('Loading additional core components if installed.')
-                    dr.load_components(*config.RULES_COMPONENTS)
-                except Exception as e:
-                    engine_logger.warning('Exception loading additional components:', e)
-            else:
-                engine_logger.warning('No RULES_COMPONENTS defined in config. '
-                                      'Running Engine with no rule plugins.')
-            self.loaded = True
+        # Load the base insights-core specs
+        engine_logger.info('Loading base insights-core components.')
+        dr.load_components(
+            'insights.specs.default',
+            'insights.specs.insights_archive',
+            continue_on_error=False
+        )
+        # Try to load additional components if they have been installed
+        if len(config.RULES_COMPONENTS):
+            engine_logger.info(f'Loading additional core components if installed: {config.RULES_COMPONENTS}')
+            dr.load_components(*config.RULES_COMPONENTS, continue_on_error=False)
+        else:
+            engine_logger.warning('No RULES_COMPONENTS defined in config. '
+                                  'Running Engine with no rule plugins.')
 
 
     def get_engine_results(self, file):


### PR DESCRIPTION
We no longer have a requirement to lazy-load rule components for the Engine. When new rules, plugins, or content is updated, the Engine will simply be restarted, which will then reload all respective artifacts.