### PR TITLE
Add /status endpoint

### DIFF
--- a/advisor_engine/endpoints.py
+++ b/advisor_engine/endpoints.py
@@ -80,6 +80,27 @@ def handle_diagnosis(insights_id):
     }
 
 
+def handle_status():
+    config_var_dir = dir(config)
+    config_vars = {}
+    for config_var in config_var_dir:
+        if (not config_var.startswith('__') and
+                config_var not in ['os', 'socket']):
+            config_vars[config_var] = getattr(config, config_var)
+
+    current_count = (len([name for name in os.listdir(config.UPLOAD_DIR)]) 
+                        if os.path.exists(config.UPLOAD_DIR) else f'{config.UPLOAD_DIR} dir not found.')
+    failed_count = (len([name for name in os.listdir(config.FAILED_DIR)])
+                        if os.path.exists(config.FAILED_DIR) else f'{config.FAILED_DIR} dir not found.')
+
+    return {
+        'engine': 'up',  # Engine assumed up. Will fail on initialization if not
+        'failed': failed_count,
+        'current': current_count,
+        'config': config_vars
+    }
+
+
 app = FastAPI()
 
 app.post('/api/ingress/v1/upload/{path:path}')(handle_insights_archive)
@@ -90,3 +111,4 @@ app.get('/r/insights/v1/systems/{path:path}')(handle_system_get_legacy)
 app.get('/api/inventory/v1/hosts')(handle_system_get)
 app.post('/api/remediations/v1/playbook')(handle_playbook)
 app.get('/api/remediations/v1/diagnosis/{insights_id}')(handle_diagnosis)
+app.get('/status')(handle_status)


### PR DESCRIPTION
This adds the `/status` endpoint that serves the following information:
```
{
    'engine': 'up',
    'failed': <int>,  # Number of present failed archives in FAILED_DIR,
    'current': <int>,  # Number of present archives in UPLOADS_DIR,
    'config': {}  # The current loaded configuration
}
```