### PR TITLE
Add ping API and upload failsafe/response for client --test-connection

### DIFF
--- a/advisor_engine/endpoints.py
+++ b/advisor_engine/endpoints.py
@@ -3,18 +3,21 @@ import os
 import os.path
 from uuid import UUID
 import aiofiles
-from fastapi import UploadFile, File, Body, FastAPI
+from fastapi import UploadFile, File, Body, FastAPI, status
 from fastapi.responses import Response, FileResponse
 from fastapi.staticfiles import StaticFiles
+from typing import Optional
 
-from advisor_engine import foreman, config, content
+from advisor_engine import foreman, config, content, loggers
 from advisor_engine.archive_processor import process_background
 
 rules = content.get_rule_content()
+api_logging = loggers.api_logging()
 
 # Create the static directory if it does not exist
 if not os.path.exists(config.STATIC_CONTENT_DIR):
     os.makedirs(config.STATIC_CONTENT_DIR)
+
 
 def handle_module_update_router():
     return {'url': '/release'}
@@ -28,12 +31,15 @@ def handle_system_get(insights_id: UUID = '00000000-0000-0000-0000-000000000000'
     return {"total": 1, "results": [{"id": insights_id}]}
 
 
-async def handle_insights_archive(file: UploadFile = File(...)):
-    file_location = os.path.join(config.UPLOAD_DIR, file.filename)
-    async with aiofiles.open(file_location, 'wb') as out_file:
-        while content := await file.read(1024 * 1024):
-            await out_file.write(content)
-    process_background(file_location)
+async def handle_insights_archive(file: Optional[UploadFile] = File(None)):
+    try:
+        file_location = os.path.join(config.UPLOAD_DIR, file.filename)
+        async with aiofiles.open(file_location, 'wb') as out_file:
+            while content := await file.read(1024 * 1024):
+                await out_file.write(content)
+        process_background(file_location)
+    except Exception as e:
+        api_logging.exception('Erorr processing archive:', e)
     return {'message': 'File uploaded successfully'}
 
 
@@ -80,6 +86,11 @@ def handle_diagnosis(insights_id):
     }
 
 
+def handle_api_ping():
+    # Just want to send back a 200 for the Client/Satellite
+    return Response(status_code=status.HTTP_200_OK)
+
+
 app = FastAPI()
 
 app.post('/api/ingress/v1/upload/{path:path}')(handle_insights_archive)
@@ -90,3 +101,4 @@ app.get('/r/insights/v1/systems/{path:path}')(handle_system_get_legacy)
 app.get('/api/inventory/v1/hosts')(handle_system_get)
 app.post('/api/remediations/v1/playbook')(handle_playbook)
 app.get('/api/remediations/v1/diagnosis/{insights_id}')(handle_diagnosis)
+app.get('/api/apicast-tests/ping')(handle_api_ping)


### PR DESCRIPTION
This MR adds the following to fix the `--test-connection` functionality
- New API endpoint for `/api/apicast-tests/ping` used by Satellite and the Client
- Ensures the client receives a 200 OK back on upload