### PR TITLE
Add host_exists endpoint

### DIFF
--- a/advisor_engine/endpoints.py
+++ b/advisor_engine/endpoints.py
@@ -30,6 +30,8 @@ def handle_system_get_legacy():
 def handle_system_get(insights_id: UUID = '00000000-0000-0000-0000-000000000000'):
     return {"total": 1, "results": [{"id": insights_id}]}
 
+def handle_system_exists(insights_id: UUID = '00000000-0000-0000-0000-000000000000'):
+    return {"id": insights_id}
 
 async def handle_insights_archive(file: Optional[UploadFile] = File(None),
                                   test: str=Form(None)):
@@ -123,6 +125,7 @@ app.get('/api/module-update-router/v1/channel')(handle_module_update_router)
 app.mount('/r/insights/v1/static/release/', StaticFiles(directory=config.STATIC_CONTENT_DIR), name='static')
 app.get('/r/insights/v1/systems/{path:path}')(handle_system_get_legacy)
 app.get('/api/inventory/v1/hosts')(handle_system_get)
+app.get('/api/inventory/v1/host_exists')(handle_system_exists)
 app.post('/api/remediations/v1/playbook')(handle_playbook)
 app.get('/api/remediations/v1/diagnosis/{insights_id}')(handle_diagnosis)
 app.get('/status')(handle_status)

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import tempfile
 import unittest
@@ -49,7 +50,9 @@ class TestEndpoints(unittest.TestCase):
         self.assertEqual(response.json(), {'message': 'File uploaded successfully'})
 
         os.unlink(temp_file_path)
-        os.unlink('uploads/test_archive.tar.gz')
+        files = glob.glob("uploads/*.gz")
+        for file in files:
+            os.remove(file)
 
     def test_handle_test_insights_archive(self):
         response = self.client.post(

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -27,6 +27,12 @@ class TestEndpoints(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"total": 1, "results": [{"id": str(test_uuid)}]})
 
+    def test_handle_system_exists(self):
+        test_uuid = UUID("12345678-1234-5678-1234-567812345678")
+        response = self.client.get(f"/api/inventory/v1/host_exists?insights_id={test_uuid}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": str(test_uuid)})
+
     @patch('advisor_engine.endpoints.process_background')
     def test_handle_insights_archive(self, mock_process_background):
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:


### PR DESCRIPTION
Adds a new mock endpoint at `/api/inventory/v1/host_exists?insights_id={id}`

that returns
```
{
    "id": "<UUID>"
}
```
Where UUID is the id passed in for insights id.  This should fix `insights-client --diagnosis` when using insights-core >= 3.5.11


Also fixes unit tests from a previous change.